### PR TITLE
Fix title rendering

### DIFF
--- a/src/manim_code_blocks.py
+++ b/src/manim_code_blocks.py
@@ -172,6 +172,7 @@ class CodeBlock(VGroup):
 
             self.code_background = background_rect
             self.title_background = lang_background
+            self.title = lang_name
 
             super().__init__(background_rect, markup, lang_background, lang_name, **kwargs)
         else: 


### PR DESCRIPTION
The `title` and `title_background` were never rendered because the `title` attribute of the CodeBlock class was never set. Because the `lang_name` gets created and never used for rendering I thought the intention was to use it as the title.

If this was not the indented use-case I will happily change my pull request. :)